### PR TITLE
Give names to sentinel values in the CDDL

### DIFF
--- a/cddl/cri.cddl
+++ b/cddl/cri.cddl
@@ -1,7 +1,7 @@
 ; not expressed in this CDDL spec: trailing nulls to be left off
 
 CRI-Reference = [
-  ((scheme / keep-scheme, authority / no-authority)
+  ((scheme / null, authority / no-authority)
    // discard),                 ; relative reference
   path / null,
   query / null,


### PR DESCRIPTION
What "null" and "true" means in terms of authority has caused confusion (eg. in the test vectors).

This gives more explicit names to them by defining constants.

Defining the constants for scheme and discard too might be excessive; I can cut that back again.

(What this does make more complicated is understanding why all the alternatives are mutually exclusive, not sure we can do that w/o going for hungarian notation.)