### PR TITLE
pet: Allow bytes, make non-zero

### DIFF
--- a/draft-ietf-core-href.md
+++ b/draft-ietf-core-href.md
@@ -731,8 +731,8 @@ query       = [*text-or-pet]
 text-or-pet = text /
     ([*(text, pet), ?text]) .feature "extended-cri"
 
-; pet is perent-encoded text
-pet = text
+; pet is perent-encoded bytes
+pet = bytes .ne ''
 ~~~
 
 That is, for each of the host-name, path, and query segments, for each


### PR DESCRIPTION
Bytes allow covering the full set of URI oddities.

`.ne ''` is an easy measure against needlessly chunked strings.

Closes: https://github.com/core-wg/href/issues/17

---

Some more could be done in analogy to the non-zeroness for the regular strings (forcing this to be minimally encoded), but not sure it's worth the verbosity. (In particular, the first repetition would become special in that it allows a zero-length zeroth component, and (by being nonoptional) also ensuring the pet doesn't degrade into a single-element array that could just as well have been a text).