### PR TITLE
tests: questionmarks in paths need to be percent encoded

### DIFF
--- a/tests/tests.json
+++ b/tests/tests.json
@@ -395,10 +395,17 @@
       "resolved-uri": "a:b/c"
     },
     {
-      "uri": "a:b?c",
+      "uri": "a:b%3Fc",
       "cri": "836161f58163623f63",
-      "uri-from-cri": "a:b?c",
+      "uri-from-cri": "a:b%3Fc",
       "resolved-cri": "836161f58163623f63",
+      "resolved-uri": "a:b%3Fc"
+    },
+    {
+      "uri": "a:b?c",
+      "cri": "846161F5816162816163",
+      "uri-from-cri": "a:b?c",
+      "resolved-cri": "846161F5816162816163",
       "resolved-uri": "a:b?c"
     },
     {


### PR DESCRIPTION
This splits the example into what the URI said (there is a query
parameter) and what the CRI said (there is a question mark in the path).

---

This is the only error I've identified so far in the tests; note that I'm only resolving CRIs and converting CRIs to URIs so far, so the "uri" fields are generally still unchecked by me.