### PR TITLE
Extra test vectors

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -16,11 +16,13 @@ Each test vector is organized as follows:
 
 | Key Name | Description |
 | --- | --- |
+| `description` | Text about the test, eg. why it is relevant, or why it is hard |
 | `uri` | a URI reference |
 | `cri` | hex-encoded CBOR representation of the CRI reference corresponding to `uri` |
 | `uri-from-cri` | the URI obtained translating the CRI reference `cri` |
 | `resolved-cri` | hex-encoded CBOR representation of the resolved CRI reference relative to the [base CRI](#bases) |
 | `resolved-uri` | resolved URI relative to the [base URI](#bases) |
+| `invalid` | is present if the CRI violates the specification |
 
 ## Test Logics
 

--- a/tests/tests.json
+++ b/tests/tests.json
@@ -708,6 +708,159 @@
       "uri-from-cri": "?a&b&c",
       "resolved-cri": "84218263666f6f1912678262706162746883616161626163",
       "resolved-uri": "coaps://foo:4711/pa/th?a&b&c"
+    },
+    {
+      "description": "Empty CRI",
+      "uri": null,
+      "cri": "80",
+      "uri-from-cri": null,
+      "resolved-cri": "8221f6",
+      "resolved-uri": "coaps:"
+    },
+    {
+      "description": "Dotted host name",
+      "uri": "//a.b",
+      "cri": "82f68261616162",
+      "uri-from-cri": "//a.b",
+      "resolved-cri": "82218261616162",
+      "resolved-uri": "coaps://a.b"
+    },
+    {
+      "description": "Weird non-PET in host",
+      "uri": "//a%2Ea",
+      "cri": "82f68163612e61",
+      "uri-from-cri": "//a%2Ea",
+      "resolved-cri": "82218163612e61",
+      "resolved-uri": "coaps://a%2Eb",
+      "invalid": "The dot ('.') is unreserved, and thus never percent encoded, and thus (when used with a delimiter) not legal in the strings of the host"
+    },
+    {
+      "description": "PET (':') in host",
+      "uri": "//a%3Aa",
+      "cri": "82f681836161413a6161",
+      "uri-from-cri": "//a%3Aa",
+      "resolved-cri": "822181836161413a6161",
+      "resolved-uri": "coaps://a%3Aa"
+    },
+    {
+      "description": "Non-PET in path",
+      "uri": "/a%2Fa%25a",
+      "cri": "82f58165612f612561",
+      "uri-from-cri": "/a%2Fa%25a",
+      "resolved-cri": "83218263666F6F1912678165612F612561",
+      "resolved-uri": "coaps://foo:4711/a%2Fa%25a"
+    },
+    {
+      "description": "Semicolon in path (pretty tame, but contrasting the next example)",
+      "uri": "/a;a",
+      "cri": "82f58163613b61",
+      "uri-from-cri": "/a;a",
+      "resolved-cri": "83218263666F6F1912678163613B61",
+      "resolved-uri": "coaps://foo:4711/a;a"
+    },
+    {
+      "description": "PET in path",
+      "uri": "/a%3Ba",
+      "cri": "82f581836161413b6161",
+      "uri-from-cri": "/a%3Ba",
+      "resolved-cri": "83218263666F6F19126781836161413B6161",
+      "resolved-uri": "coaps://foo:4711/a%3Ba"
+    },
+    {
+      "description": "escaped non-PET in query (discarding path without empty trailing)",
+      "uri": null,
+      "cri": "83f5808163612661",
+      "uri-from-cri": null,
+      "resolved-cri": "84218263666F6F191267808163612661",
+      "resolved-uri": "coaps://foo:4711?a%26a"
+    },
+    {
+      "description": "escaped non-PET in query (discarding path but restoring an empty trailing path component)",
+      "uri": "/?a%26a",
+      "cri": "83F581608163612661",
+      "uri-from-cri": "/?a%26a",
+      "resolved-cri": "84218263666F6F19126781608163612661",
+      "resolved-uri": "coaps://foo:4711/?a%26a"
+    },
+    {
+      "description": "PET in query",
+      "uri": "/?a%23a",
+      "cri": "83F581608183616141236161",
+      "uri-from-cri": "/?a%23a",
+      "resolved-cri": "84218263666F6F19126781608183616141236161",
+      "resolved-uri": "coaps://foo:4711/?a%23a"
+    },
+    {
+      "description": "unescaped non-PET (but delimiter) in fragment",
+      "uri": "#/",
+      "cri": "8400F6F6612F",
+      "uri-from-cri": "#/",
+      "resolved-cri": "85218263666F6F1912678262706162746881657175657279612F",
+      "resolved-uri": "coaps://foo:4711/pa/th?query#/"
+    },
+    {
+      "description": "escaped non-PET in fragment",
+      "uri": "#%5B%5D",
+      "cri": "8400f6f6625b5d",
+      "uri-from-cri": "#%5B%5D",
+      "resolved-cri": "85218263666F6F1912678262706162746881657175657279625B5D",
+      "resolved-uri": "coaps://foo:4711/pa/th?query#%5B%5D"
+    },
+    {
+      "description": "PET in fragment",
+      "uri": "#%2F",
+      "cri": "8400F6F681412F",
+      "uri-from-cri": "#%2F",
+      "resolved-cri": "85218263666F6F191267826270616274688165717565727981412F",
+      "resolved-uri": "coaps://foo:4711/pa/th?query#%2F"
+    },
+    {
+      "description": "escaped non-PET in host",
+      "uri": "//non%3Aport.x",
+      "cri": "82f682686E6F6E3A706F72746178",
+      "uri-from-cri": "//non%3Aport.x",
+      "resolved-cri": "822182686E6F6E3A706F72746178",
+      "resolved-uri": "coaps://non%3Aport.x"
+    },
+    {
+      "description": "unescaped non-PET (but delimiter) in host",
+      "uri": "//non!port.x",
+      "cri": "82F68281686E6F6E21706F72746178",
+      "uri-from-cri": "//non!port.x",
+      "resolved-cri": "82218281686E6F6E21706F72746178",
+      "resolved-uri": "coaps://non!port.x"
+    },
+    {
+      "description": "PET in host",
+      "uri": "//non%21port.x",
+      "cri": "82F68283636E6F6E412164706F72746178",
+      "uri-from-cri": "//non%21port.x",
+      "resolved-cri": "82218283636E6F6E412164706F72746178",
+      "resolved-uri": "coaps://non%21port.x"
+    },
+    {
+      "description": "escaped non-PET in userinfo",
+      "uri": "//alice%40example.com@example.com",
+      "cri": "82f684f471616c696365406578616d706c652e636f6d676578616d706c6563636f6d",
+      "uri-from-cri": "//alice%40example.com@example.com",
+      "resolved-cri": "822184F471616C696365406578616D706C652E636F6D676578616D706C6563636F6D",
+      "resolved-uri": "coaps://alice%40example.com@example.com"
+    },
+    {
+      "description": "escaped and unescaped delimiter in userinfo",
+      "uri": "//c+%2B@example.com",
+      "cri": "82F684F48262632B412B676578616D706C6563636F6D",
+      "uri-from-cri": "//c+%2B@example.com",
+      "resolved-cri": "822184F48262632B412B676578616D706C6563636F6D",
+      "resolved-uri": "coaps://c+%2B@example.com"
+    },
+    {
+      "description": "colon in first URI path needs to be preserved to disambiguate against full URIs",
+      "uri": "./foo:bar",
+      "cri": "82018167666F6F3A626172",
+      "uri-from-cri": "./foo:bar",
+      "resolved-cri": "83218263666F6F1912678262706167666F6F3A626172",
+      "resolved-uri": "coaps://foo:4711/pa/foo:bar"
     }
   ]
 }

--- a/tests/tests.json
+++ b/tests/tests.json
@@ -869,6 +869,14 @@
       "uri-from-cri": "math://equation=E%3Dmc%C2%B2/",
       "resolved-cri": "83646D61746881836A6571756174696F6E3D45413D646D63C2B28160",
       "resolved-uri": "math://equation=E%3Dmc%C2%B2/"
+    },
+    {
+      "description": "Zone in host",
+      "uri": "http://[fe80::1%25eth0]/",
+      "cri": "83228250FE80000000000000000000000000000164657468308160",
+      "uri-from-cri": "http://[fe80::1%25eth0]/",
+      "resolved-cri": "83228250FE80000000000000000000000000000164657468308160",
+      "resolved-uri": "http://[fe80::1%25eth0]/"
     }
   ]
 }

--- a/tests/tests.json
+++ b/tests/tests.json
@@ -395,10 +395,17 @@
       "resolved-uri": "a:b/c"
     },
     {
-      "uri": "a:b?c",
+      "uri": "a:b%3Fc",
       "cri": "836161f58163623f63",
-      "uri-from-cri": "a:b?c",
+      "uri-from-cri": "a:b%3Fc",
       "resolved-cri": "836161f58163623f63",
+      "resolved-uri": "a:b%3Fc"
+    },
+    {
+      "uri": "a:b?c",
+      "cri": "846161F5816162816163",
+      "uri-from-cri": "a:b?c",
+      "resolved-cri": "846161F5816162816163",
       "resolved-uri": "a:b?c"
     },
     {

--- a/tests/tests.json
+++ b/tests/tests.json
@@ -861,6 +861,14 @@
       "uri-from-cri": "./foo:bar",
       "resolved-cri": "83218263666F6F1912678262706167666F6F3A626172",
       "resolved-uri": "coaps://foo:4711/pa/foo:bar"
+    },
+    {
+      "description": "PET in contrast to unescaped subdelim in hostname",
+      "uri": "math://equation=E%3Dmc%C2%B2/",
+      "cri": "83646D61746881836A6571756174696F6E3D45413D646D63C2B28160",
+      "uri-from-cri": "math://equation=E%3Dmc%C2%B2/",
+      "resolved-cri": "83646D61746881836A6571756174696F6E3D45413D646D63C2B28160",
+      "resolved-uri": "math://equation=E%3Dmc%C2%B2/"
     }
   ]
 }

--- a/tests/tests.json
+++ b/tests/tests.json
@@ -24,13 +24,6 @@
       "resolved-uri": "coaps://192.168.0.97"
     },
     {
-      "uri": "",
-      "cri": "8100",
-      "uri-from-cri": "",
-      "resolved-cri": "85218263666f6f19126782627061627468816571756572796466726167",
-      "resolved-uri": "coaps://foo:4711/pa/th?query#frag"
-    },
-    {
       "uri": "/",
       "cri": "82f58160",
       "uri-from-cri": "/",
@@ -711,11 +704,11 @@
     },
     {
       "description": "Empty CRI",
-      "uri": null,
+      "uri": "",
       "cri": "80",
-      "uri-from-cri": null,
-      "resolved-cri": "8221f6",
-      "resolved-uri": "coaps:"
+      "uri-from-cri": "",
+      "resolved-cri": "85218263666f6f19126782627061627468816571756572796466726167",
+      "resolved-uri": "coaps://foo:4711/pa/th?query#frag"
     },
     {
       "description": "Dotted host name",


### PR DESCRIPTION
Now for some hard ones...

This introduces two things on the mechanism side:
* Test descriptions. Thanks to JSON for not having comments.
* Tests whose uri and uri-from-cri is null. This is on precisely the tests where the reference can not be expressed as a URI. Resolved URIs are still present, because all CRIs are also URIs (just the CRI references are more expressive). Implementations may skip the URI conversion on the references, or attempt to convert the CRI to a URI and require the conversion to fail.
* Tests with an "invalid" entry are, in some form, invalid CRIs. Implementations may skip them, or just silence errors but not crashes, or (if they check thoroughly) even require errors to be raised.

That being said, these tests are what I needed to get OKish coverage, and to flush out places where I knew my implementation was incomplete. It contains PETs and non-PET things that do or do not need escaping in a lot of places, plus tests for things that will get separate issues shortly (like the last one)