### PR TITLE
Reference cddl-control / RFC9165

### DIFF
--- a/draft-ietf-core-href.md
+++ b/draft-ietf-core-href.md
@@ -74,6 +74,7 @@ normative:
     seriesinfo:
       ISBN: 978-1-936213-26-9
   RFC8949: cbor
+  RFC9165: cddlcontrol
 
 --- abstract
 
@@ -397,7 +398,7 @@ resolved to their respective CRI before comparison.
 
 A CRI or CRI reference is encoded as a CBOR array {{RFC8949}}, with the
 structure as described in the [Concise Data Definition Language
-(CDDL)](#RFC8610) as follows: [^replace-xxxx]
+(CDDL)](#RFC8610) [including its control extensions](#RFC9165) as follows: [^replace-xxxx]
 
 ~~~~ cddl
 {::include cddl/cri.cddl}


### PR DESCRIPTION
We use .feature, so it's normative.

(Context: I've been looking for drafts that uses .feature, and found nothing in the inbound references of 9165, but should have.)