### PR TITLE
balun example: Use two artworks

### DIFF
--- a/draft-ietf-core-href.md
+++ b/draft-ietf-core-href.md
@@ -971,6 +971,8 @@ Both the following examples are therefore not valid:
 
 ~~~ cbor-diag
 [-6, true, [["web:alice:", '7:', "1-balun"]]]
+~~~
+~~~ cbor-diag
 [-6, true, [["web:alice:7", ':1', "-balun"]]]
 ~~~
 


### PR DESCRIPTION
If annotated as cbor-diag, the artwork should be valid EDN (at least for a CBOR sequence), but the two lines on their own are not.