### PR TITLE
no indefinite lengths: Suggest that formats including this still do it

### DIFF
--- a/draft-ietf-core-href.md
+++ b/draft-ietf-core-href.md
@@ -490,9 +490,11 @@ simple values as defined in {{-packed}}.
 
 For interchange as separate encoded data items, CRIs MUST NOT use
 indefinite length encoding (see
-{{Section 3.2 of RFC8949@-cbor}}); this requirement is relaxed for
+{{Section 3.2 of RFC8949@-cbor}}). This requirement is relaxed for
 specifications that embed CRIs into an encompassing CBOR
-representation that does provide for indefinite length encoding.
+representation that does provide for indefinite length encoding;
+those might still consider such a mandate for their CBOR items
+to aid constrained implementations.
 
 ### `scheme-name` and `scheme-id` {#scheme-id}
 

--- a/draft-ietf-core-href.md
+++ b/draft-ietf-core-href.md
@@ -490,11 +490,13 @@ simple values as defined in {{-packed}}.
 
 For interchange as separate encoded data items, CRIs MUST NOT use
 indefinite length encoding (see
-{{Section 3.2 of RFC8949@-cbor}}). This requirement is relaxed for
+{{Section 3.2 of RFC8949@-cbor}}).
+This requirement is relaxed for
 specifications that embed CRIs into an encompassing CBOR
 representation that does provide for indefinite length encoding;
-those might still consider such a mandate for their CBOR items
-to aid constrained implementations.
+those specifications that are selective in where they provide for
+indefinite length encoding are RECOMMENDED to not provide it for
+embedded CRIs.
 
 ### `scheme-name` and `scheme-id` {#scheme-id}
 


### PR DESCRIPTION
I'm aware we can't add any mandate on this, but downstream protocol designers might. For consumers, it is tremendously helpful: It allows them to use CRI references in memory references and pass them on.

I'll definitely consider doing this for CoRAL -- indefinite length might be allowed there, eg. for embedded representations, but for CRIs it'd still follow this recommendation.