### PR TITLE
Don't allow null path for CRI in CDDL

### DIFF
--- a/cddl/cri.cddl
+++ b/cddl/cri.cddl
@@ -5,7 +5,7 @@ RFC-XXXX-Definitions = [CRI, CRI-Reference]
 CRI = [
   scheme,
   authority / no-authority,
-  path / null,
+  path,                         ; use [] for empty path
   query / null,
   fragment / null
 ]

--- a/draft-ietf-core-href.md
+++ b/draft-ietf-core-href.md
@@ -561,7 +561,7 @@ references:
 |-----------|---------------|
 | scheme    | –             |
 | authority | null          |
-| discard   | –             |
+| discard   | 0             |
 | path      | []            |
 | query     | null          |
 | fragment  | null          |

--- a/draft-ietf-core-href.md
+++ b/draft-ietf-core-href.md
@@ -545,7 +545,7 @@ This CDDL specification is simplified for exposition and needs to be
 augmented by the following rules for interchange of CRIs and CRI
 references:
 
-* Trailing null values MUST be removed.
+* Trailing default values ({{tbl-default}}) MUST be removed.
 * Two leading null values (scheme and authority both not given) MUST
   be represented by using the `discard` alternative instead.
 * An empty path in a `CRI` MUST be represented as the empty array
@@ -555,7 +555,17 @@ references:
 * An empty outer array (`[]`) is not a valid CRI.
   It is a valid CRI reference,
   equivalent to `[0]` as per {{ingest}}, which essentially copies the
-  base CRI.
+  base CRI up to and including the path section, unsetting query and fragment.
+
+| Section   | Default Value |
+|-----------|---------------|
+| scheme    | –             |
+| authority | null          |
+| discard   | –             |
+| path      | []            |
+| query     | null          |
+| fragment  | null          |
+{:#tbl-default title="Default Values for CRI Sections"}
 
 Application specifications that use CRIs may explicitly enable the use
 of "stand-in" items (tags or simple values).


### PR DESCRIPTION
What's next?
A table of Defaults would be great, but these seem to differ for CRIs and CRI References.