### PR TITLE
implementations: Add Rust implementation, note Python impl's age.

### DIFF
--- a/draft-ietf-core-href.md
+++ b/draft-ietf-core-href.md
@@ -1369,13 +1369,12 @@ AIF-CRI = AIF-Generic<CRI-local-part, REST-method-set>
 
 {::boilerplate rfc7942info}
 
-A golang implementation of version -10 of this document is found at:
-`https://github.com/thomas-fossati/href`
-A Rust implementation is available at https://codeberg.org/chrysn/cri-ref;
-it is being updated to version -18 at the time of writing.
-A python implementation is available as part of `https://gitlab.com/chrysn/micrurus
-but severely outdated (based on version -05).
-<!-- see RFC 7942 -->
+A golang implementation of revision -10 of this document is found at:
+`https://github.com/thomas-fossati/href`.
+A Rust implementation is available at `https://codeberg.org/chrysn/cri-ref`;
+it is being updated to revision -18 at the time of writing.
+A python implementation is available as part of `https://gitlab.com/chrysn/micrurus`
+but is based on revision -05.
 
 # Security Considerations {#security}
 

--- a/draft-ietf-core-href.md
+++ b/draft-ietf-core-href.md
@@ -1369,10 +1369,12 @@ AIF-CRI = AIF-Generic<CRI-local-part, REST-method-set>
 
 {::boilerplate rfc7942info}
 
-With the exception of the authority=true fix, host-names split into
-labels, and {{pet}}, CRIs are implemented in `https://gitlab.com/chrysn/micrurus`.
 A golang implementation of version -10 of this document is found at:
 `https://github.com/thomas-fossati/href`
+A Rust implementation is available at https://codeberg.org/chrysn/cri-ref;
+it is being updated to version -18 at the time of writing.
+A python implementation is available as part of `https://gitlab.com/chrysn/micrurus
+but severely outdated (based on version -05).
 <!-- see RFC 7942 -->
 
 # Security Considerations {#security}


### PR DESCRIPTION
The text that was there on missing features is obsolete because those were just not in the version that was current at the time of writing. (IIRC, that text was accurate at the time of writing: then, it was on the latest version but just did not implement all the WIP features of the editor's copy).