### PR TITLE
Remove my postal address

### DIFF
--- a/draft-ietf-core-href.md
+++ b/draft-ietf-core-href.md
@@ -42,9 +42,6 @@ contributor:
   country: Sweden
   email: klaus.hartke@ericsson.com
 - name: Christian Amsüss
-  street: Hollandstr. 12/4
-  city: Vienna
-  code: 1020
   country: Austria
   email: christian@amsuess.com
 


### PR DESCRIPTION
While it's out there and not secret, and do not plan on moving, this is not a business address. (This is also consistent with my published documents).