### PR TITLE
Add text to 8.1 that can handle other transport addresses

### DIFF
--- a/draft-ietf-core-href.md
+++ b/draft-ietf-core-href.md
@@ -1303,6 +1303,18 @@ This section provides an analogue to {{Sections 6.4 and 6.5 of -coap}}:
 Computing a set of CoAP options from a request CRI ({{decompose-coap}}) and computing a
 request CRI from a set of COAP options ({{compose-coap}}).
 
+As with {{Sections 6.4 and 6.5 of -coap}}, the (intended or actually
+used) request's destination transport address is considered an
+additional parameter to these algorithms, usually used to be able to
+elide (by supplying default values for) CoAP options that would
+contain components of this transport address.
+As with {{Sections 6.4 and 6.5 of -coap}}, the text in this section
+speaks about the request's destination IP address and the request's
+destination UDP port as components of the request's destination
+transport address used in this way; transports that do not have these
+components or have other components that are to be used in this way
+need to specify the specifics.
+
 This section makes use of the mapping between CRI scheme numbers
 and URI scheme names shown in {{scheme-map}}:
 

--- a/draft-ietf-core-href.md
+++ b/draft-ietf-core-href.md
@@ -1313,7 +1313,7 @@ speaks about the request's destination IP address and the request's
 destination UDP port as components of the request's destination
 transport address used in this way; transports that do not have these
 components or have other components that are to be used in this way
-need to specify the specifics.
+need to specify their own URI conversion, which then applies here as well.
 
 This section makes use of the mapping between CRI scheme numbers
 and URI scheme names shown in {{scheme-map}}:


### PR DESCRIPTION
Section 8.1 is about the conversion between CoAP CRIs ⇄ CoAP Options.

This is a draft pull request on top of #131; if accepted it will be added to #131 and then be merged with that.