### PR TITLE
(Indirectly) point to test vectors via the external site links...

### DIFF
--- a/draft-ietf-core-href.md
+++ b/draft-ietf-core-href.md
@@ -1762,8 +1762,8 @@ This appendix lists a few corner cases of URI semantics that
 implementers of CRIs need to be aware of, but that are not
 representative of the normal operation of CRIs.
 
-Additional test vectors may be available via the external site links
-kept by the CoRE WG Wiki, <https://wiki.ietf.org/group/core>.
+Additional test vectors may be available 
+through the CoRE WG Wiki, <https://wiki.ietf.org/group/core>.
 
 {:sp}
 1. {:#sp-leading-empty} Initial (Lone/Leading) Empty Path Segments:

--- a/draft-ietf-core-href.md
+++ b/draft-ietf-core-href.md
@@ -1762,7 +1762,7 @@ This appendix lists a few corner cases of URI semantics that
 implementers of CRIs need to be aware of, but that are not
 representative of the normal operation of CRIs.
 
-Additional test vectors may be available 
+Additional test vectors may be available
 through the CoRE WG Wiki, <https://wiki.ietf.org/group/core>.
 
 {:sp}

--- a/draft-ietf-core-href.md
+++ b/draft-ietf-core-href.md
@@ -1762,6 +1762,9 @@ This appendix lists a few corner cases of URI semantics that
 implementers of CRIs need to be aware of, but that are not
 representative of the normal operation of CRIs.
 
+Additional test vectors may be available via the external site links
+kept by the CoRE WG Wiki, <https://wiki.ietf.org/group/core>.
+
 {:sp}
 1. {:#sp-leading-empty} Initial (Lone/Leading) Empty Path Segments:
 


### PR DESCRIPTION
...kept by the CoRE WG Wiki, <https://wiki.ietf.org/group/core>.

As this will be all we will be saying about additional test vectors in this document, this closes the extant issues on test vectors close #52
close #53
close #77